### PR TITLE
Fixed composer.json after update to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require":{
         "php":">=5.3.2",
         "symfony/console":"*",
-        "composer/composer":"*",
+        "composer/composer":"dev-master",
         "slim/slim":"1.6.2",
         "dflydev/markdown":"dev-master"
     },
@@ -23,5 +23,6 @@
         "psr-0":{
             "rg":"src/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "6916c720e664061e7a2471105143f60e",
+    "hash": "d380183d2c0721b6b040daf336c1acab",
     "packages": [
         {
             "package": "composer/composer",
@@ -10,8 +10,8 @@
         {
             "package": "composer/composer",
             "version": "dev-master",
-            "source-reference": "a2171e2ed1a6f9a8125163cb05947294d67cd4c0",
-            "commit-date": "1345108950"
+            "source-reference": "de4e9c4022fb68f2f6bb79e0ed56e4ae8afdd6b7",
+            "commit-date": "1345048183"
         },
         {
             "package": "dflydev/markdown",
@@ -74,14 +74,13 @@
             "commit-date": "1343512949"
         }
     ],
-    "packages-dev": [
-
-    ],
+    "packages-dev": null,
     "aliases": [
 
     ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "composer/composer": 20,
         "dflydev/markdown": 20
     }
 }

--- a/src/rg/broker/commands/AddRepository.php
+++ b/src/rg/broker/commands/AddRepository.php
@@ -90,7 +90,14 @@ class AddRepository extends \Symfony\Component\Console\Command\Command {
                                        \Composer\Package\PackageInterface $package,
                                        $zipfileName) {
         $packageArray = $dumper->dump($package);
-        $reference = $packageArray['dist']['reference'];
+	if (!empty($packageArray['dist']['reference'])) {
+            $reference = $packageArray['dist']['reference'];
+	} else if (!empty($packageArray['source']['reference'])) {
+	    $reference = $packageArray['source']['reference'];
+	} else {
+	    throw new \Exception("No reference found");
+	}
+
         unset($packageArray['source']);
         unset($packageArray['dist']);
 


### PR DESCRIPTION
- Fixed situation when no dist but only source reference is given.
- If none is given, throw exception
