### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require":{
         "php":">=5.3.2",
-        "symfony/console":"*",
+        "symfony/console":"2.1.*",
         "composer/composer":"dev-master",
         "slim/slim":"1.6.2",
         "dflydev/markdown":"dev-master"


### PR DESCRIPTION
If I dont add 2.1.\* as a dependency for the console, I get the following -

Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfony/console dev-master -> satisfiable by symfony/console dev-master, symfony/
symfony dev-master, symfony/symfony 2.2.x-dev.
    - Conclusion: don't install symfony/console 2.2.x-dev
    - Installation request for symfony/console 2.1.x-dev -> satisfiable by symfony/console 2.1.x-dev, symfony/sy
mfony 2.1.x-dev.
    - Conclusion: don't install symfony/console 2.2.x-dev
    - Can only install one of: symfony/symfony 2.2.x-dev, symfony/symfony 2.1.x-dev.
    - don't install symfony/process 2.1.x-dev|don't install symfony/symfony 2.2.x-dev
    - don't install symfony/symfony 2.2.x-dev|don't install symfony/process 2.1.x-dev
    - Installation request for symfony/console 2.2.x-dev -> satisfiable by symfony/console 2.2.x-dev, symfony/sy
mfony 2.2.x-dev.
    - Installation request for symfony/process 2.1.x-dev -> satisfiable by symfony/process 2.1.x-dev, symfony/sy
mfony 2.1.x-dev.
