### PR TITLE
Update to work with new composer version

### DIFF
--- a/src/rg/broker/repositories/Repository.php
+++ b/src/rg/broker/repositories/Repository.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  */
 namespace rg\broker\repositories;
+use Composer\Package\Loader\ArrayLoader;
 
 class Repository extends \Composer\Repository\ComposerRepository {
 
@@ -18,6 +19,8 @@ class Repository extends \Composer\Repository\ComposerRepository {
         $this->url = ROOT . '/repositories/' .$name;
         $this->cache = new \rg\broker\customizations\Cache();
         $this->io = new \Composer\IO\NullIO();
+        $this->loader = new ArrayLoader();
+        $this->options = array();
     }
 
     public function getName() {


### PR DESCRIPTION
The overriding of the constructor causes issues with the latest version of composer - this seems to fix them.

I guess it might be more robust to call the parent constructor, as we are relying on composer internals...
