### PR TITLE
Compatibility with PHP Built-In web server provided

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,5 +10,10 @@
 require __DIR__ . '/config.php';
 require __DIR__ . '/autoload.php';
 
+$requestedFile = $_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME'];
+if (php_sapi_name() == 'cli-server' && file_exists($requestedFile) && !is_dir($requestedFile)) {
+    return false; // Documentation: http://php.net/manual/en/features.commandline.webserver.php
+}
+
 $application = new \rg\broker\web\Application();
 $application->run();


### PR DESCRIPTION
Documentation details about this non-evident approach:
http://php.net/manual/en/features.commandline.webserver.php

Now it is possible to run PHP Built-In web server in broker directory:
php -S localhost:8080 ./index.php

Before the change: 404 on any access to repositories/.../packages.json
